### PR TITLE
Add CLAUDE.md and development reference documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,44 @@
+# CLAUDE.md
+
+## Workflow
+
+Always work on a git worktree, not the main repository.
+
+1. **Spec** - Understand the task and read relevant code first
+2. **Plan** - Use plan mode to design the approach
+3. **Draft** - Implement the changes
+4. **Simplify** - Review and simplify the solution
+5. **Update Tests** - Add or update tests for changed functionality
+6. **Update Docs** - Update roxygen comments and `dev/` documentation
+7. **Test** - Run `devtools::test()`
+8. **Verify** - Run `devtools::check(args = "--no-tests")` (skip tests since already run)
+9. **Quality Check** - Use a subagent to verify code quality and safety
+10. **Commit & PR** - Commit changes and create a pull request
+
+## Quick Commands
+
+```bash
+Rscript -e "devtools::test()"                       # Run tests
+Rscript -e "devtools::check(args = '--no-tests')"   # R CMD check (skip tests)
+Rscript -e "devtools::document()"                   # Regenerate docs
+Rscript -e "devtools::load_all()"                   # Load for testing
+```
+
+## Project Structure
+
+```
+R/                  # Source code
+man/                # Documentation (auto-generated, don't edit)
+tests/testthat/     # Tests (testthat edition 3)
+dev/                # Development docs
+```
+
+## Reference
+
+See `dev/01_claude_reference.md` for:
+- Key source files and their purposes
+- Core functions
+- Development conventions
+- Dependencies
+
+See `dev/91_improvement_plan.md` for the roadmap.

--- a/dev/01_claude_reference.md
+++ b/dev/01_claude_reference.md
@@ -1,0 +1,46 @@
+# Claude Reference - NEPSroutines
+
+## Project Overview
+
+NEPSroutines is an R package for scaling NEPS (National Educational Panel Study) competence data. It implements IRT (Item Response Theory) routines for 1PL and 2PL models with binary and polytomous responses.
+
+## Key Source Files
+
+| File | Purpose |
+|------|---------|
+| `R/irt_analyses.R` | Core IRT modeling functions |
+| `R/data_preparation.R` | Data validation and preparation |
+| `R/dif_analysis.R` | Differential item functioning |
+| `R/dimensionality_analysis.R` | Dimensionality testing |
+| `R/linking.R` | Cross-wave parameter linking |
+| `R/utils.R` | Utility and validation functions |
+| `R/technical_report_*.r` | Quarto report generation |
+
+## Core Functions
+
+- `irt_analysis()` - Main IRT analysis entry point
+- `dif_analysis()` - DIF testing
+- `dim_analysis()` - Dimensionality analysis
+- `linking()` - Parameter linking across waves
+- `mv_item()`, `mv_person()` - Missing value analysis
+- `prepare_resp()` - Data preparation
+- `create_scores()`, `create_suf()` - Score generation
+
+## Development Conventions
+
+### Documentation
+- Uses roxygen2 - edit comments in R files, then run `devtools::document()`
+- Never edit `man/*.Rd` files directly
+
+### Testing
+- Framework: testthat (edition 3)
+- Test fixtures in `tests/testthat/fixtures/`
+- Run with `devtools::test()`
+
+### Dependencies
+- Core: TAM (IRT), ggplot2, dplyr/tidyr, haven
+- R version: >= 4.3.0
+
+## Common Mistakes to Avoid
+
+(Add learnings here when Claude makes errors)


### PR DESCRIPTION
Add AI assistant documentation following Boris Cherny's workflow pattern:
- CLAUDE.md: Minimal file with 10-step workflow, quick commands, project structure
- dev/01_claude_reference.md: Detailed reference for key files, functions, conventions