### PR TITLE
Add testthat skill for R package testing guidance

### DIFF
--- a/.claude/skills/testthat/SKILL.md
+++ b/.claude/skills/testthat/SKILL.md
@@ -284,7 +284,7 @@ Use withr for temporary changes. Never use:
 This project (NEPSroutines) uses these testing patterns:
 
 ### Fixtures Location
-Test fixtures are stored in `tests/testthat/fixtures/` with subdirectories for different test scenarios (ex1, ex2).
+Test fixtures are stored in `tests/testthat/fixtures/` with subdirectories for different test scenarios (e.g., ex1, ex2, ex3).
 
 ### Common Expectations Used
 - `expect_no_error()` for function execution success


### PR DESCRIPTION
## Summary
- Adds a Claude Code skill for testthat, providing comprehensive guidance when writing or evaluating R package tests
- Includes complete reference for all expectation functions, skip functions, mocking, fixtures, and best practices
- Contains project-specific patterns based on NEPSroutines existing test structure

## Test plan
- [ ] Verify skill is triggered when discussing tests or reviewing test files
- [ ] Test manual invocation with `/testthat`
- [ ] Confirm skill content is accurate and helpful for writing tests

🤖 Generated with [Claude Code](https://claude.ai/code)
