### PR TITLE
Add Claude Code project permissions for R development workflow

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,13 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(Rscript -e \"devtools::*\")",
+      "Bash(git status*)",
+      "Bash(git diff*)",
+      "Bash(git log*)",
+      "Bash(git add *)",
+      "Bash(git commit *)",
+      "Bash(gh pr create *)"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Add `.claude/settings.json` with project-specific permissions
- Configure allowed Bash commands for R package development workflow:
  - `devtools::*` functions (test, check, document, load_all, etc.)
  - Git read operations (status, diff, log)
  - Git write operations (add, commit)
  - GitHub CLI for PR creation

## Test plan
- [ ] Verify permissions work by running `devtools::test()` without prompts
- [ ] Verify git commands work without prompts

🤖 Generated with [Claude Code](https://claude.com/claude-code)