### PR TITLE
Fix notification escalation levels

### DIFF
--- a/R/create_scores.R
+++ b/R/create_scores.R
@@ -294,7 +294,7 @@ create_scores <- function(
     # Select
     if (is.null(sum_select)) {
       sum_select <- select
-      warning("\nNo variable 'sum_select' provided for sum scores. All items as ",
+      message("No variable 'sum_select' provided for sum scores. All items as ",
               "specified in variable '", select, "' are used instead.")
     }
 
@@ -332,7 +332,7 @@ create_scores <- function(
 
     if (is.null(meta_select)) {
       meta_select <- select
-      warning("\nNo variable 'meta_select' provided for meta scores. All items as ",
+      message("No variable 'meta_select' provided for meta scores. All items as ",
               "specified in variable '", select, "' are used instead.")
     }
 

--- a/R/descriptives.R
+++ b/R/descriptives.R
@@ -18,7 +18,7 @@ n_valid <- function(resp, valid = NULL) {
     } else {
         n_inval <- 0
         n_val <- nrow(resp)
-        warn("No variable to identify (in)valid cases provided. Thus, all cases are counted as valid.")
+        message("No variable to identify (in)valid cases provided. Thus, all cases are counted as valid.")
     }
 
     message("There are ", n_val, " valid cases and ", n_inval, " invalid cases ",

--- a/R/dif_analysis.R
+++ b/R/dif_analysis.R
@@ -1195,7 +1195,7 @@ print_dif_summary <- function(resp, diflist, res, dif_threshold = 0.5) {
     message("\nMain effects of DIF model and main effects model:\n")
 
     for (i  in names(res$mne)) {
-        cat(paste0("Comparison ", i, ":\n"))
+        message("Comparison ", i, ":")
         print(res$mne[[i]])
     }
 
@@ -1203,17 +1203,16 @@ print_dif_summary <- function(resp, diflist, res, dif_threshold = 0.5) {
     message("\nItems exhibiting problematic DIF (|xsi| >= ", dif_threshold, "):\n")
 
     for (i  in names(res$est)) {
-        cat(paste0("Comparison ", i, ":\n"))
+        message("Comparison ", i, ":")
         f <- abs(res$est[[i]]$xsi) >= dif_threshold
         if (any(f)) {
             sig <- res$est[[i]]$p < .05
             res$est[[i]]$p <- paste0(round(res$est[[i]]$p, 3), ifelse(sig, "*", ""))
             print(res$est[[i]][f, ])
-            if (any(sig)) cat("\n*: p < .05")
+            if (any(sig)) message("*: p < .05")
         } else {
-            cat("No items found.")
+            message("No items found.")
         }
-        cat("\n\n")
     }
 }
 

--- a/R/linking.R
+++ b/R/linking.R
@@ -1540,7 +1540,8 @@ calculate_link_parameters <- function(vars_curr,
 
         if (any(!anchors[, 1] %in% row.names(xsi_prev)) |
             any(!anchors[, 2] %in% row.names(xsi_curr.linked))) {
-            stop("")
+            stop("Anchor items in 'anchors' do not match item names in the IRT models. ",
+                 "Please check that all anchor items exist in both the previous and current datasets.")
         }
         const.err <- sd(xsi_prev[anchors[, 1], "xsi"] -
                             xsi_curr.linked[anchors[, 2], 2]) / sqrt(nrow(anchors))
@@ -1703,53 +1704,50 @@ print_link_results <- function(link_dif,
     }
 
     # Print N longitudinal subsample, N link study
-    cat(paste0(N, "\n"))
+    message(N)
 
     # Print DIF table
-    cat("DIF estimates for anchor items:\n")
+    message("DIF estimates for anchor items:")
     print(link_dif$link_dif_summary$link_dif_table)
-    cat(paste0("\n",
-               "Items with potential DIF:\n",
-               "|xsi| < ", dif_threshold, " or p < 0.05 (marked with +) \n",
-               "|xsi| < ", dif_threshold, " and p < 0.05 (marked with *) \n\n"))
+    message("\nItems with potential DIF:\n",
+            "|xsi| < ", dif_threshold, " or p < 0.05 (marked with +)\n",
+            "|xsi| < ", dif_threshold, " and p < 0.05 (marked with *)")
 
     # Print critical F for DIF
-    cat("The critical values for the DIF between time points are:\n")
+    message("The critical values for the DIF between time points are:")
     Fs <- unique(link_dif$link_dif_summary$Fkrit)
     dfs <- sapply(Fs, \(x) {
         link_dif$link_dif_summary$dfkrit[link_dif$link_dif_summary$Fkrit == x][1]
     })
-    cat(paste0("F(1, ", dfs, ") = ", round(Fs, digits = digits), "\n"))
-    cat("\n")
+    message(paste0("F(1, ", dfs, ") = ", round(Fs, digits = digits), collapse = "\n"))
 
     # Print range of DIF
     xsi <- round(abs(link_dif$link_dif_summary$link_dif_table$xsi), digits = digits)
-    cat(paste0("Min. / max. abs. estimate: ",
-               paste(range(xsi, na.rm = TRUE), collapse = ", "), "\n\n"))
+    message("Min. / max. abs. estimate: ",
+            paste(range(xsi, na.rm = TRUE), collapse = ", "))
 
     # Print link constant and link error (link_results)
-    const <- paste0("Linking constant: ", round(link_results$const, digits = digits), "\n",
-                    "Linking error: ", round(link_results$const.err, digits = digits), "\n")
-    cat(paste0(const, "\n"))
+    message("Linking constant: ", round(link_results$const, digits = digits), "\n",
+            "Linking error: ", round(link_results$const.err, digits = digits))
 
     # Print GoF for dimensionality analyses
     if (!is.null(link_dif$mod_link)) {
-        cat("\nDimensionality analysis results for link study:")
-        cat("\nFactor correlations (off-diagonal) with variances (diagonal):\n")
+        message("\nDimensionality analysis results for link study:")
+        message("\nFactor correlations (off-diagonal) with variances (diagonal):")
         print(round(link_dim$dim_sum$`Cor-Var wave`, digits = digits))
-        cat("\nGoodness-of-fit indices for unidimensional (uni) and two-dimensional (wave) model:\n")
+        message("\nGoodness-of-fit indices for unidimensional (uni) and two-dimensional (wave) model:")
         print(link_dim$dim_sum$`Goodness Of fit`)
     } else {
-        cat("\nDimensionality analysis results for previous test:\n")
-        cat("\nFactor correlations (off-diagonal) with variances (diagonal):\n")
+        message("\nDimensionality analysis results for previous test:")
+        message("\nFactor correlations (off-diagonal) with variances (diagonal):")
         print(round(link_dim$dim_sum$previous$`Cor-Var anchoritems`, digits = digits))
-        cat("\nGoodness-of-fit indices for unidimensional and two-dimensional model:\n")
+        message("\nGoodness-of-fit indices for unidimensional and two-dimensional model:")
         print(link_dim$dim_sum$previous$`Goodness Of fit`)
 
-        cat("\nDimensionality analysis results for current test:\n")
-        cat("\nFactor correlations (off-diagonal) with variances (diagonal):\n")
+        message("\nDimensionality analysis results for current test:")
+        message("\nFactor correlations (off-diagonal) with variances (diagonal):")
         print(round(link_dim$dim_sum$current$`Cor-Var anchoritems`, digits = digits))
-        cat("\nGoodness-of-fit indices for unidimensional and two-dimensional model:\n")
+        message("\nGoodness-of-fit indices for unidimensional and two-dimensional model:")
         print(link_dim$dim_sum$current$`Goodness Of fit`)
     }
 }

--- a/R/mv_item.R
+++ b/R/mv_item.R
@@ -974,7 +974,7 @@ mvi_plots <- function(
     )
 
     # Print progress
-    if (verbose) cat("Missing plot", i, "created.\n")
+    if (verbose) message("Missing plot ", i, " created.")
   }
 }
 

--- a/R/mv_person.R
+++ b/R/mv_person.R
@@ -603,7 +603,7 @@ mvp_plots <- function(
         )
 
         # Print progress
-        if (verbose) cat("Missing plot", i, "created.\n")
+        if (verbose) message("Missing plot ", i, " created.")
     }
 }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -14,8 +14,8 @@ only_valid <- function(resp, valid = NULL, warn = TRUE) {
       check_logicals(resp, "resp", valid, warn = warn)
       resp <- resp[resp[[valid]], ]
   } else if (warn) {
-      warning("No variable with valid cases provided. ",
-              "All cases are used for analysis.\n")
+      message("No variable with valid cases provided. ",
+              "All cases are used for analysis.")
   }
 
   return(resp)
@@ -46,8 +46,8 @@ convert_mv <- function(resp, vars, select = NULL, mvs = NULL, warn = TRUE) {
     mvs <- -999:-1
 
     if (warn) {
-      warning("No user defined missing values provided for item responses. ",
-              "Default of '-999 to -1' is used.\n")
+      message("No user defined missing values provided for item responses. ",
+              "Default of '-999 to -1' is used.")
     }
   }
 
@@ -120,7 +120,7 @@ prepare_resp <- function(
             resp <- resp[ , items]
         }
     } else if (warn) {
-        warning("No variable provided indicating the items to keep. ",
+        message("No variable provided indicating the items to keep. ",
                 "All items are kept.")
     }
 
@@ -146,13 +146,13 @@ prepare_resp <- function(
 
 is_null_mvs_valid <- function(mvs = NA, valid = NA) {
   if (is.null(mvs)) {
-    warning("No user defined missing values provided. ",
-            "Default of '-999 to -1' is used.\n")
+    message("No user defined missing values provided. ",
+            "Default of '-999 to -1' is used.")
   }
 
   if (is.null(valid)) {
-    warning("No variable with valid cases provided. ",
-            "All cases are used for analysis.\n")
+    message("No variable with valid cases provided. ",
+            "All cases are used for analysis.")
   }
   return(invisible())
 }
@@ -227,7 +227,7 @@ save_results <- function(results, filename, path) {
 check_folder <- function(path) {
     if (!file.exists(path)) {
         dir.create(path, recursive = TRUE)
-        warning("The location ", path, " did not exist. New folder created.\n")
+        message("The location ", path, " did not exist. New folder created.")
     }
   return(invisible())
 }
@@ -452,19 +452,13 @@ meht <- function(stat, df1, df2, eta2 = NULL, delta = .40,
     pnil <- pf(stat, df1, df2, lower.tail = FALSE) # p for nil hypothesis test
 
     if (verbose) {
-        cat("\nNil hypothesis test:\n")
-        cat("   Critical F-value: F(", df1, ",", df2, ") = ",
-            round(Fnil, digits), "\n",
-            sep = ""
-        )
-        cat("   p for F = ", stat, ": p = ", round(pnil, digits), "\n", sep = "")
-
-        cat("\nMinimum effect hypothesis test:\n")
-        cat("   Critical F-value: F(", df1, ", ", df2, ", ", round(ncp, digits), ") = ",
-            round(Fmin, digits), "\n",
-            sep = ""
-        )
-        cat("   p for F = ", stat, ": p = ", round(pmin, digits), "\n\n", sep = "")
+        message("\nNil hypothesis test:")
+        message("   Critical F-value: F(", df1, ",", df2, ") = ", round(Fnil, digits))
+        message("   p for F = ", stat, ": p = ", round(pnil, digits))
+        message("\nMinimum effect hypothesis test:")
+        message("   Critical F-value: F(", df1, ", ", df2, ", ", round(ncp, digits), ") = ",
+                round(Fmin, digits))
+        message("   p for F = ", stat, ": p = ", round(pmin, digits))
     }
 
     out <- list(

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -5,9 +5,9 @@ test_that("only_valid() works", {
                      valid = c(rep(TRUE, 8), rep(FALSE, 2)))
 
   expect_no_error(only_valid(resp = resp, valid = NULL, warn = FALSE))
-  expect_warning(only_valid(resp = resp, valid = NULL, warn = TRUE),
+  expect_message(only_valid(resp = resp, valid = NULL, warn = TRUE),
                  regexp = "^No variable with valid cases provided.+")
-  expect_no_warning(only_valid(resp = resp, valid = NULL, warn = FALSE))
+  expect_no_message(only_valid(resp = resp, valid = NULL, warn = FALSE))
   expect_equal(nrow(only_valid(resp = resp, valid = NULL, warn = FALSE)), 10)
   expect_error(only_valid(resp = resp, valid = "something", warn = TRUE),
                regexp = "^Data.frame resp does not include any variable.+")
@@ -31,10 +31,10 @@ test_that("convert_mv() works", {
   )
 
   # mvs not set
-  expect_warning(convert_mv(resp = resp, vars = vars, select = NULL,
+  expect_message(convert_mv(resp = resp, vars = vars, select = NULL,
                             mvs = NULL, warn = TRUE),
                  regexp = "^No user defined missing values provided.+")
-  expect_no_warning(convert_mv(resp = resp, vars = vars, select = NULL,
+  expect_no_message(convert_mv(resp = resp, vars = vars, select = NULL,
                                mvs = NULL, warn = FALSE))
 
   # select is incorrect
@@ -83,9 +83,9 @@ test_that("prepare_resp() works", {
                regexp = "^To create a data frame \\(resp\\) with only the.+")
 
   # select not set or incorrect
-  expect_warning(prepare_resp(resp = resp, select = NULL, warn = TRUE),
+  expect_message(prepare_resp(resp = resp, select = NULL, warn = TRUE),
                  regexp = "^No variable provided indicating the items.+")
-  expect_no_warning(prepare_resp(resp = resp, select = NULL, warn = FALSE))
+  expect_no_message(prepare_resp(resp = resp, select = NULL, warn = FALSE))
   expect_error(prepare_resp(resp = resp, vars = vars, select = "dontuse"),
                regexp = "^Data.frame vars does not include any variable.+")
 
@@ -135,8 +135,8 @@ test_that("check_folder() works", {
   path <- withr::local_tempdir()
 
   expect_no_error(check_folder(path))
-  expect_no_warning(check_folder(path))
-  expect_warning(check_folder(paste0(path, "/emptyfolder")))
+  expect_no_message(check_folder(path))
+  expect_message(check_folder(paste0(path, "/emptyfolder")))
   expect_true(dir.exists(paste0(path, "/emptyfolder")))
 
 })


### PR DESCRIPTION
Closes #64

## Summary

- **Fix critical bug**: `warn()` in `descriptives.R` (undefined function) → `message()`
- **Fix critical bug**: Empty `stop("")` in `linking.R` → meaningful error message explaining anchor item mismatch
- **Demote warnings → messages** for "using defaults" scenarios (these are informational, not problematic):
  - `only_valid()`: no valid variable provided, all cases used
  - `convert_mv()`: no missing values provided, default `-999:-1` used
  - `prepare_resp()`: no select variable, all items kept
  - `is_null_mvs_valid()`: missing values / valid variable not provided
  - `check_folder()`: folder created (informational action)
  - `create_scores()`: no `sum_select`/`meta_select` provided, using defaults
- **Replace `cat()` with `message()`** for consistency with package conventions (allows `suppressMessages()`):
  - `dif_analysis.R`: comparison labels and footnotes
  - `linking.R`: all output in `print_linking_results()`
  - `mv_item.R`, `mv_person.R`: verbose plot creation progress
  - `utils.R`: verbose output in `meht()`

## Test plan

- [x] All 164 tests pass (4 skipped due to missing packages/files)
- [x] Tests in `test-utils.R` updated to use `expect_message()`/`expect_no_message()` instead of `expect_warning()`/`expect_no_warning()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)