### PR TITLE
Fixed bug with tables in technical reports

### DIFF
--- a/inst/_extensions/neps-paper/neps-paper-header.tex
+++ b/inst/_extensions/neps-paper/neps-paper-header.tex
@@ -69,9 +69,14 @@
 \newcommand{\elandscape}{\newpage\normalpapersize}
 	%\KOMAoptions{paper=portrait,pagesize}
 	%\recalctypearea
-	
+
 % Wiederverwendbarkeit von Fussnoten mittels \label
 \makeatletter
 \newcommand\footnoteref[1]{\protected@xdef\@thefnmark{\ref{#1}}\@footnotemark}
 \makeatother
 \setlength{\parskip}\medskipamount
+
+% Weird bug: after flexttables italic text is not recognized anymore
+\usepackage[normalem]{ulem}
+\renewcommand{\emph}[1]{\textit{#1}}
+


### PR DESCRIPTION
Tbl() printed underline instead of italic text after tables in technical reports. This seems to be a bug in flextable() and was fixed in the latex template.