### PR TITLE
Forward anonymous arguments to Tbl() in specialized table functions (#111)

### DIFF
--- a/R/technical_report_tables.r
+++ b/R/technical_report_tables.r
@@ -152,6 +152,7 @@ Tbl <- function(obj, footnote = NULL, autofit = TRUE, merge = TRUE, lbl = NULL,
 #' @param footnote A table note.
 #' @param na.rm A logical to remove empty properties.
 #' @param formats Long names of item properties to be displayed in the table.
+#' @param ... Further arguments passed to [Tbl()].
 #' @returns A flextable.
 #' @inheritParams Tbl
 #' @inheritParams collapse_response_categories
@@ -184,7 +185,7 @@ Tbl <- function(obj, footnote = NULL, autofit = TRUE, merge = TRUE, lbl = NULL,
 #' }
 TblItemProps <- function(vars, select, prop, propname = "", footnote = NULL,
                          na.rm = TRUE, size = 12, width = NULL,
-                         formats = NULL) {
+                         formats = NULL, ...) {
 
     # Create frequency table
     freq_groups <- NULL
@@ -223,7 +224,7 @@ TblItemProps <- function(vars, select, prop, propname = "", footnote = NULL,
     # Create flextable
     ft <- Tbl(freq_groups, align = c("left", rep("center", length(select))),
               hline = nrow(freq_groups) - 1, footnote = footnote,
-              size = size, width = width)
+              size = size, width = width, ...)
     return (ft)
 
   }
@@ -239,6 +240,7 @@ TblItemProps <- function(vars, select, prop, propname = "", footnote = NULL,
 #' @param position The variable name in `vars` giving the item position.
 #' @param footnote A table note.
 #' @param lbl Long names of item facets to be displayed in the table.
+#' @param ... Further arguments passed to [Tbl()].
 #' @returns A flextable.
 #' @inheritParams Tbl
 #' @inheritParams collapse_response_categories
@@ -266,7 +268,7 @@ TblItemProps <- function(vars, select, prop, propname = "", footnote = NULL,
 #' }
 TblItemFacets <- function(vars, select, facets, position = NULL,
                           footnote = NULL, size = 12, width = 1.9,
-                          lbl = NULL, rename_collapsed = TRUE) {
+                          lbl = NULL, rename_collapsed = TRUE, ...) {
 
   # Select variables
   cols <- c("item", facets)
@@ -294,7 +296,7 @@ TblItemFacets <- function(vars, select, facets, position = NULL,
 
   # Create flextable
   if (length(width) == 1) width <- c(0.3, rep(width, ncol(tab) - 1))
-  ft <- Tbl(tab, footnote = footnote, width = width, size = size)
+  ft <- Tbl(tab, footnote = footnote, width = width, size = size, ...)
   ft <- flextable::colformat_double(ft, j = 1, digits = 0)
   return (ft)
 
@@ -311,6 +313,7 @@ TblItemFacets <- function(vars, select, facets, position = NULL,
 #' @param footnote An optional table note.
 #' @param sort A column name to indicate by which column to sort.
 #' @param excl A vector of column names to exclude.
+#' @param ... Further arguments passed to [Tbl()].
 #' @returns A flextable.
 #' @inheritParams Tbl
 #' @export
@@ -350,7 +353,7 @@ TblItemFacets <- function(vars, select, facets, position = NULL,
 #' }
 TblMvi <- function(obj, select = NULL, footnote = NULL, sort = "position",
                    size = 12, width = NULL,
-                   excl = c("N_administered", "ND", "ALL", "...1")) {
+                   excl = c("N_administered", "ND", "ALL", "...1"), ...) {
 
   # Result table
   if (is.list(obj) & "list" %in% names(obj))
@@ -441,7 +444,7 @@ TblMvi <- function(obj, select = NULL, footnote = NULL, sort = "position",
   note <- append(note, footnote)
 
   # Create flextable
-  ft <- Tbl(tab, footnote = note, size = size, width = width)
+  ft <- Tbl(tab, footnote = note, size = size, width = width, ...)
   if ("Pos." %in% colnames(tab))
     ft <- flextable::colformat_double(ft, j = "Pos.", digits = 0)
   if ("Total" %in% colnames(tab))
@@ -465,6 +468,7 @@ TblMVI <- TblMvi
 #' [irt_analysis()].
 #' @param rename_collapsed A boolean to remove the "_collapsed" suffix from
 #' item names.
+#' @param ... Further arguments passed to [Tbl()].
 #' @returns A flextable.
 #' @inheritParams Tbl
 #' @inheritParams TblMvi
@@ -502,7 +506,7 @@ TblMVI <- TblMvi
 #' TblPars(pars, excl = NULL, footnote = "Nothing to report.")
 #' }
 TblPars <- function(obj, footnote = NULL, excl = c("N_administered"),
-                    size = 10, width = 0.5, rename_collapsed = TRUE) {
+                    size = 10, width = 0.5, rename_collapsed = TRUE, ...) {
 
   # Result table
   if (is.list(obj) & "summary" %in% names(obj))
@@ -595,7 +599,7 @@ TblPars <- function(obj, footnote = NULL, excl = c("N_administered"),
     note <- append(note, footnote)
 
   # Create flextable
-  ft <- Tbl(tab, size = size, width = width, footnote = note)
+  ft <- Tbl(tab, size = size, width = width, footnote = note, ...)
   if ("Nr." %in% colnames(tab)) {
     ft <- flextable::colformat_double(ft, j = 1, digits = 0)
     ft <- flextable::width(ft, j = "Nr.", width = .3)
@@ -640,6 +644,7 @@ TblPars <- function(obj, footnote = NULL, excl = c("N_administered"),
 #' @param obj A list with data frames with sheets from "irt_poly.xlsx"
 #' or sheet "steps" from "irt_poly.xlsx" created by [irt_analysis()].
 #' @param digits A number for rounding.
+#' @param ... Further arguments passed to [Tbl()].
 #' @returns A flextable.
 #' @inheritParams Tbl
 #' @inheritParams TblMvi
@@ -677,7 +682,7 @@ TblPars <- function(obj, footnote = NULL, excl = c("N_administered"),
 #' TblSteps(pars, size = 12, footnote = "Nothing to note.")
 #' }
 TblSteps <- function(obj, footnote = NULL, size = 10, width = 1, digits = 2,
-                     rename_collapsed = TRUE) {
+                     rename_collapsed = TRUE, ...) {
 
   # Result table
   if (is.list(obj) & "steps" %in% names(obj))
@@ -721,7 +726,7 @@ TblSteps <- function(obj, footnote = NULL, size = 10, width = 1, digits = 2,
     width <- rep(width, ncol(tab))
     width[1] <- max(nchar(tab$Item)) * .085
   }
-  ft <- Tbl(tab, footnote = note, size = size, width = width)
+  ft <- Tbl(tab, footnote = note, size = size, width = width, ...)
   return(ft)
 
 }
@@ -738,6 +743,7 @@ TblSteps <- function(obj, footnote = NULL, size = 10, width = 1, digits = 2,
 #' @param width The column widths; if a single value is given, it refers to the
 #' first column; otherwise the number of values must correspond to the number of
 #' columns in `obj`.
+#' @param ... Further arguments passed to [Tbl()].
 #' @return A flextable.
 #' @inheritParams Tbl
 #' @inheritParams TblMvi
@@ -776,7 +782,7 @@ TblSteps <- function(obj, footnote = NULL, size = 10, width = 1, digits = 2,
 #'        rownames = c("Units", "Change", "Space", "Data"))
 #' }
 TblDim <- function(obj, model, rownames = NULL, colnames = NULL,
-                   footnote = NULL, size = 12, width = 3) {
+                   footnote = NULL, size = 12, width = 3, ...) {
 
   # Get table
   obj <- obj[[paste0("Cor-Var ", model)]]
@@ -818,7 +824,7 @@ TblDim <- function(obj, model, rownames = NULL, colnames = NULL,
 
   # Create flextable
   if (length(width) == 1) width <- c(width, rep(0.6, ncol(tab) - 1))
-  ft <- Tbl(tab, footnote = note, size = size, width = width)
+  ft <- Tbl(tab, footnote = note, size = size, width = width, ...)
   ft <- flextable::bold(ft, j = 1, part = "body")
   ft <- flextable::align(ft, j = 1, align = "left", part = "body")
   return(ft)
@@ -841,6 +847,7 @@ TblDim <- function(obj, model, rownames = NULL, colnames = NULL,
 #' corresponds to the first column; otherwise the number of values must
 #' correspond to the number of columns in `obj`.
 #' @param digits A number for rounding.
+#' @param ... Further arguments passed to [Tbl()].
 #' @return A flextable.
 #' @inheritParams Tbl
 #' @inheritParams TblMvi
@@ -881,7 +888,7 @@ TblDim <- function(obj, model, rownames = NULL, colnames = NULL,
 TblDif <- function(obj, footnote = NULL, excl = NULL,
                    colnames1 = NULL, colnames2 = NULL,
                    width = 1.4, size = 10, digits = 2,
-                   rename_collapsed = TRUE) {
+                   rename_collapsed = TRUE, ...) {
 
   # Result table
   if (is.list(obj) & "estimates" %in% names(obj))
@@ -952,7 +959,7 @@ TblDif <- function(obj, footnote = NULL, excl = NULL,
   # Create flextable
   if (length(width) == 1) width <- c(width, rep(1, ncol(tab) - 1))
   ft <- Tbl(tab, footnote = note, size = size, width = width,
-            hline = nrow(tab) - 2, lbl = lbl)
+            hline = nrow(tab) - 2, lbl = lbl, ...)
   ft <- flextable::add_header_row(ft, top = FALSE, values = vals)
   ft <- flextable::style(ft, i = 2, part = "header",
                          pr_t = officer::fp_text(bold = FALSE))
@@ -972,6 +979,7 @@ TblDIF <- TblDif
 #'
 #' @param excl A vector of DIF variables that should be excluded.
 #' @param label A vector of names for the DIF variables.
+#' @param ... Further arguments passed to [Tbl()].
 #' @return A flextable.
 #' @inheritParams TblDif
 #' @export
@@ -1007,7 +1015,7 @@ TblDIF <- TblDif
 #' TblDifFit(dif$TR, excl= "sex", label = c("mig" = "Migrant background"))
 #' }
 TblDifFit <-function(obj, footnote = NULL, excl = NULL, label = NULL,
-                     size = 12, width = 0.9) {
+                     size = 12, width = 0.9, ...) {
 
   # Result table
   if (is.list(obj) & "gof" %in% names(obj))
@@ -1042,7 +1050,7 @@ TblDifFit <-function(obj, footnote = NULL, excl = NULL, label = NULL,
 
   # Create flextable
   ft <- Tbl(tab, footnote = note, size = size, width = width,
-            digits = 0)
+            digits = 0, ...)
   ft <- flextable::merge_v(ft, j = 1, part = "body")
   ft <- flextable::compose(
     ft, i = 1, j = "N", part = "header",

--- a/R/technical_report_tables.r
+++ b/R/technical_report_tables.r
@@ -152,7 +152,8 @@ Tbl <- function(obj, footnote = NULL, autofit = TRUE, merge = TRUE, lbl = NULL,
 #' @param footnote A table note.
 #' @param na.rm A logical to remove empty properties.
 #' @param formats Long names of item properties to be displayed in the table.
-#' @param ... Further arguments passed to [Tbl()].
+#' @param ... Further arguments passed to [Tbl()]; `align` and `hline` are set
+#' internally and will error if also passed here.
 #' @returns A flextable.
 #' @inheritParams Tbl
 #' @inheritParams collapse_response_categories
@@ -743,7 +744,8 @@ TblSteps <- function(obj, footnote = NULL, size = 10, width = 1, digits = 2,
 #' @param width The column widths; if a single value is given, it refers to the
 #' first column; otherwise the number of values must correspond to the number of
 #' columns in `obj`.
-#' @param ... Further arguments passed to [Tbl()].
+#' @param ... Further arguments passed to [Tbl()]. The first column (dimension
+#' labels) is always left-aligned, so any `align` passed here does not affect it.
 #' @return A flextable.
 #' @inheritParams Tbl
 #' @inheritParams TblMvi
@@ -847,7 +849,8 @@ TblDim <- function(obj, model, rownames = NULL, colnames = NULL,
 #' corresponds to the first column; otherwise the number of values must
 #' correspond to the number of columns in `obj`.
 #' @param digits A number for rounding.
-#' @param ... Further arguments passed to [Tbl()].
+#' @param ... Further arguments passed to [Tbl()]; `hline` and `lbl` are set
+#' internally and will error if also passed here.
 #' @return A flextable.
 #' @inheritParams Tbl
 #' @inheritParams TblMvi
@@ -979,7 +982,8 @@ TblDIF <- TblDif
 #'
 #' @param excl A vector of DIF variables that should be excluded.
 #' @param label A vector of names for the DIF variables.
-#' @param ... Further arguments passed to [Tbl()].
+#' @param ... Further arguments passed to [Tbl()]; `digits` is set internally and
+#' will error if also passed here.
 #' @return A flextable.
 #' @inheritParams TblDif
 #' @export

--- a/man/TblDif.Rd
+++ b/man/TblDif.Rd
@@ -14,7 +14,8 @@ TblDif(
   width = 1.4,
   size = 10,
   digits = 2,
-  rename_collapsed = TRUE
+  rename_collapsed = TRUE,
+  ...
 )
 
 TblDIF(
@@ -26,7 +27,8 @@ TblDIF(
   width = 1.4,
   size = 10,
   digits = 2,
-  rename_collapsed = TRUE
+  rename_collapsed = TRUE,
+  ...
 )
 }
 \arguments{
@@ -56,6 +58,8 @@ correspond to the number of columns in `obj`.}
 
 \item{rename_collapsed}{A boolean to remove the "_collapsed" suffix from
 item names.}
+
+\item{...}{Further arguments passed to [Tbl()].}
 }
 \value{
 A flextable.

--- a/man/TblDif.Rd
+++ b/man/TblDif.Rd
@@ -59,7 +59,8 @@ correspond to the number of columns in `obj`.}
 \item{rename_collapsed}{A boolean to remove the "_collapsed" suffix from
 item names.}
 
-\item{...}{Further arguments passed to [Tbl()].}
+\item{...}{Further arguments passed to [Tbl()]; `hline` and `lbl` are set
+internally and will error if also passed here.}
 }
 \value{
 A flextable.

--- a/man/TblDifFit.Rd
+++ b/man/TblDifFit.Rd
@@ -42,7 +42,8 @@ or a data frame with sheet "estimates" from "dif_poly_TR.xlsx" created by
 corresponds to the first column; otherwise the number of values must
 correspond to the number of columns in `obj`.}
 
-\item{...}{Further arguments passed to [Tbl()].}
+\item{...}{Further arguments passed to [Tbl()]; `digits` is set internally and
+will error if also passed here.}
 }
 \value{
 A flextable.

--- a/man/TblDifFit.Rd
+++ b/man/TblDifFit.Rd
@@ -11,7 +11,8 @@ TblDifFit(
   excl = NULL,
   label = NULL,
   size = 12,
-  width = 0.9
+  width = 0.9,
+  ...
 )
 
 TblDIFFit(
@@ -20,7 +21,8 @@ TblDIFFit(
   excl = NULL,
   label = NULL,
   size = 12,
-  width = 0.9
+  width = 0.9,
+  ...
 )
 }
 \arguments{
@@ -39,6 +41,8 @@ or a data frame with sheet "estimates" from "dif_poly_TR.xlsx" created by
 \item{width}{The widths of the columns; if a single values is given, it
 corresponds to the first column; otherwise the number of values must
 correspond to the number of columns in `obj`.}
+
+\item{...}{Further arguments passed to [Tbl()].}
 }
 \value{
 A flextable.

--- a/man/TblDim.Rd
+++ b/man/TblDim.Rd
@@ -34,7 +34,8 @@ reference model and the name of the facet variable.}
 first column; otherwise the number of values must correspond to the number of
 columns in `obj`.}
 
-\item{...}{Further arguments passed to [Tbl()].}
+\item{...}{Further arguments passed to [Tbl()]. The first column (dimension
+labels) is always left-aligned, so any `align` passed here does not affect it.}
 }
 \value{
 A flextable.

--- a/man/TblDim.Rd
+++ b/man/TblDim.Rd
@@ -11,7 +11,8 @@ TblDim(
   colnames = NULL,
   footnote = NULL,
   size = 12,
-  width = 3
+  width = 3,
+  ...
 )
 }
 \arguments{
@@ -32,6 +33,8 @@ reference model and the name of the facet variable.}
 \item{width}{The column widths; if a single value is given, it refers to the
 first column; otherwise the number of values must correspond to the number of
 columns in `obj`.}
+
+\item{...}{Further arguments passed to [Tbl()].}
 }
 \value{
 A flextable.

--- a/man/TblItemFacets.Rd
+++ b/man/TblItemFacets.Rd
@@ -13,7 +13,8 @@ TblItemFacets(
   size = 12,
   width = 1.9,
   lbl = NULL,
-  rename_collapsed = TRUE
+  rename_collapsed = TRUE,
+  ...
 )
 }
 \arguments{
@@ -41,6 +42,8 @@ number of columns in `obj`.}
 
 \item{rename_collapsed}{A boolean to remove the "_collapsed" suffix from
 item names.}
+
+\item{...}{Further arguments passed to [Tbl()].}
 }
 \value{
 A flextable.

--- a/man/TblItemProps.Rd
+++ b/man/TblItemProps.Rd
@@ -43,7 +43,8 @@ number of columns in `obj`.}
 
 \item{formats}{Long names of item properties to be displayed in the table.}
 
-\item{...}{Further arguments passed to [Tbl()].}
+\item{...}{Further arguments passed to [Tbl()]; `align` and `hline` are set
+internally and will error if also passed here.}
 }
 \value{
 A flextable.

--- a/man/TblItemProps.Rd
+++ b/man/TblItemProps.Rd
@@ -13,7 +13,8 @@ TblItemProps(
   na.rm = TRUE,
   size = 12,
   width = NULL,
-  formats = NULL
+  formats = NULL,
+  ...
 )
 }
 \arguments{
@@ -41,6 +42,8 @@ will be applied to all columns; otherwise the length must correspond to the
 number of columns in `obj`.}
 
 \item{formats}{Long names of item properties to be displayed in the table.}
+
+\item{...}{Further arguments passed to [Tbl()].}
 }
 \value{
 A flextable.

--- a/man/TblMvi.Rd
+++ b/man/TblMvi.Rd
@@ -12,7 +12,8 @@ TblMvi(
   sort = "position",
   size = 12,
   width = NULL,
-  excl = c("N_administered", "ND", "ALL", "...1")
+  excl = c("N_administered", "ND", "ALL", "...1"),
+  ...
 )
 
 TblMVI(
@@ -22,7 +23,8 @@ TblMVI(
   sort = "position",
   size = 12,
   width = NULL,
-  excl = c("N_administered", "ND", "ALL", "...1")
+  excl = c("N_administered", "ND", "ALL", "...1"),
+  ...
 )
 }
 \arguments{
@@ -43,6 +45,8 @@ will be applied to all columns; otherwise the length must correspond to the
 number of columns in `obj`.}
 
 \item{excl}{A vector of column names to exclude.}
+
+\item{...}{Further arguments passed to [Tbl()].}
 }
 \value{
 A flextable.

--- a/man/TblPars.Rd
+++ b/man/TblPars.Rd
@@ -10,7 +10,8 @@ TblPars(
   excl = c("N_administered"),
   size = 10,
   width = 0.5,
-  rename_collapsed = TRUE
+  rename_collapsed = TRUE,
+  ...
 )
 }
 \arguments{
@@ -30,6 +31,8 @@ number of columns in `obj`.}
 
 \item{rename_collapsed}{A boolean to remove the "_collapsed" suffix from
 item names.}
+
+\item{...}{Further arguments passed to [Tbl()].}
 }
 \value{
 A flextable.

--- a/man/TblSteps.Rd
+++ b/man/TblSteps.Rd
@@ -10,7 +10,8 @@ TblSteps(
   size = 10,
   width = 1,
   digits = 2,
-  rename_collapsed = TRUE
+  rename_collapsed = TRUE,
+  ...
 )
 }
 \arguments{
@@ -29,6 +30,8 @@ number of columns in `obj`.}
 
 \item{rename_collapsed}{A boolean to remove the "_collapsed" suffix from
 item names.}
+
+\item{...}{Further arguments passed to [Tbl()].}
 }
 \value{
 A flextable.

--- a/tests/testthat/test-technical_report_tables.R
+++ b/tests/testthat/test-technical_report_tables.R
@@ -295,6 +295,21 @@ test_that("specialized table functions forward ... to Tbl()", {
   # being silently swallowed (Tbl() has a closed signature, no `...`).
   expect_error(TblMvi(tab, nonexistent_arg = 1), "unused argument")
 
+  # Wrappers that hard-code structural Tbl() arguments raise a duplicate-argument
+  # error if the same name is also passed via `...` (the intended guardrail).
+  data("ex2")
+  expect_error(
+    TblItemProps(ex2$vars, select = c("Number of items" = "mixed"),
+                 prop = "type", align = "left"),
+    "matched by multiple"
+  )
+
+  # A valid, unbound Tbl() argument still forwards through a wrapper that
+  # hard-codes a different argument (TblDifFit fixes `digits`).
+  dif <- Import(test_path("fixtures", "ex1", "tables"), "dif_dich_TR.xlsx")
+  expect_s3_class(TblDifFit(dif, merge = FALSE), "flextable")
+  expect_error(TblDifFit(dif, digits = 0), "matched by multiple")
+
 })
 
 

--- a/tests/testthat/test-technical_report_tables.R
+++ b/tests/testthat/test-technical_report_tables.R
@@ -273,3 +273,28 @@ test_that("TblCode() works", {
 })
 
 
+test_that("specialized table functions forward ... to Tbl()", {
+
+  skip_if_not_installed("flextable")
+  skip_if_not_installed("officer")
+
+  tab <- Import(test_path("fixtures", "ex1", "tables"), "mv_item.xlsx")
+
+  # TblMvi() does not set `align`/`align_head` itself, so both flow through `...`
+  # to Tbl(); several Tbl() arguments can be forwarded in a single call.
+  tbl <- TblMvi(tab, align = "left", align_head = "left")
+  expect_s3_class(tbl, "flextable")
+  expect_true(all(tbl$body$styles$pars$text.align$data == "left"))
+  expect_true(all(tbl$header$styles$pars$text.align$data == "left"))
+
+  # Without `...`, Tbl()'s default centered alignment is retained.
+  tbl_default <- TblMvi(tab)
+  expect_true(all(tbl_default$body$styles$pars$text.align$data == "center"))
+
+  # An argument Tbl() does not accept errors at the Tbl() boundary rather than
+  # being silently swallowed (Tbl() has a closed signature, no `...`).
+  expect_error(TblMvi(tab, nonexistent_arg = 1), "unused argument")
+
+})
+
+


### PR DESCRIPTION
## Summary

Closes #111.

The eight specialized table wrappers each shape a results data frame and then call `Tbl()`, but each only re-exposed a small subset of `Tbl()`'s ~14 styling knobs (typically `footnote`, `size`, `width`). Everything else `Tbl()` can do (`merge`, `align_head`, `size_head`, `size_foot`, `autofit`, `hline_head`, …) was unreachable through a wrapper.

This PR adds a variadic `...` parameter to each wrapper that calls `Tbl()` and forwards it to the inner `Tbl()` call, so users can set any number of `Tbl()` styling arguments in a single call, e.g.:

```r
TblMvi(mvi, size = 11, merge = FALSE, align_head = "left", autofit = FALSE)
```

Wrappers updated: `TblItemProps`, `TblItemFacets`, `TblMvi`, `TblPars`, `TblSteps`, `TblDim`, `TblDif`, `TblDifFit`. `TblCode` is excluded (it generates code and never calls `Tbl()`); the aliases `TblMVI`/`TblDIF`/`TblDIFFit` inherit `...` automatically.

## Design notes

- **`...` is placed last** in each signature, so all existing named arguments keep positional and partial matching — fully backward compatible.
- **Typos are still caught.** `Tbl()` has a closed signature (no `...` of its own), so an unknown forwarded argument errors with `unused argument (...)` rather than being silently swallowed.
- **Structural args are guarded.** Three wrappers hard-code layout-critical arguments (`align`/`hline` in `TblItemProps`, `hline`/`lbl` in `TblDif`, `digits` in `TblDifFit`). Passing the same name via `...` raises R's duplicate-argument error by design — no silent override of table layout.

## Tests

- New `test_that("specialized table functions forward ... to Tbl()")` block verifies multiple `Tbl()` arguments forward together (`align` + `align_head` via `TblMvi`), that the default is unchanged without `...`, and that an unknown argument errors at the `Tbl()` boundary.
- `devtools::test()`: 348 pass, 0 fail.
- `devtools::check(args = "--no-tests")`: 0 errors, 0 warnings, 1 pre-existing NOTE (unused `WrightMap`/`sfsmisc` imports + `:::` self-call — unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)