### PR TITLE
Use exact name matching for excl/select in table functions (#115)

### DIFF
--- a/R/technical_report_tables.r
+++ b/R/technical_report_tables.r
@@ -320,10 +320,14 @@ TblItemFacets <- function(vars, select, facets, position = NULL,
 #' @param obj A list with data frames with sheets from "mv_item.xlsx"
 #' or a data frame with sheet "summary" from "mv_item.xlsx" created by
 #' [mv_item()].
-#' @param select An optional name of a specific group to select.
+#' @param select An optional name of a specific group to select. Columns whose
+#' names end in the group suffix (e.g. `"_mixed"`) are kept, along with the
+#' `"Nr."` and `"item"` columns; the suffix is matched literally, not as a
+#' regular expression.
 #' @param footnote An optional table note.
 #' @param sort A column name to indicate by which column to sort.
-#' @param excl A vector of column names to exclude.
+#' @param excl A vector of column names to exclude. Names are matched exactly,
+#' not as regular expressions or substrings.
 #' @param ... Further arguments passed to [Tbl()].
 #' @returns A flextable.
 #' @inheritParams Tbl
@@ -376,7 +380,9 @@ TblMvi <- function(obj, select = NULL, footnote = NULL, sort = "position",
 
   # Select results for group
   if (!is.null(select)) {
-    tab <- tab[, grepl(paste0("Nr\\.|item|_", select), colnames(tab))]
+    keep <- colnames(tab) %in% c("Nr.", "item") |
+      endsWith(colnames(tab), paste0("_", select))
+    tab <- tab[, keep]
     colnames(tab) <- sub(paste0("_", select), "", colnames(tab))
   }
 
@@ -392,10 +398,10 @@ TblMvi <- function(obj, select = NULL, footnote = NULL, sort = "position",
   # Create numbering
   tab$"Nr." <- seq_len(nrow(tab))
 
-  # Exclude columns
-  regexp <- "^$"
-  if (!is.null(excl)) regexp <- paste0(regexp, "|", paste(excl, collapse = "|"))
-  tab <- tab[, !grepl(regexp, colnames(tab))]
+  # Exclude columns by exact name (also drops unnamed columns)
+  keep <- nzchar(colnames(tab))
+  if (!is.null(excl)) keep <- keep & !(colnames(tab) %in% excl)
+  tab <- tab[, keep]
 
   # Rename variables
   lbl <- colnames(tab)
@@ -533,7 +539,7 @@ TblPars <- function(obj, footnote = NULL, excl = c("N_administered"),
 
   # Exclude columns
   if (!is.null(excl)) {
-    tab <- tab[, !grepl(paste(excl, collapse = "|"), colnames(tab))]
+    tab <- tab[, !(colnames(tab) %in% excl)]
   }
 
   # Rename collapsed items
@@ -916,7 +922,7 @@ TblDif <- function(obj, footnote = NULL, excl = NULL,
 
   # Exclude columns
   if (!is.null(excl)) {
-    tab <- tab[, !grepl(paste(excl, collapse = "|"), colnames(tab))]
+    tab <- tab[, !(colnames(tab) %in% excl)]
   }
 
   # Rename collapsed items
@@ -996,7 +1002,9 @@ TblDIF <- TblDif
 
 #' Create table with fit statistics for DIF analyses
 #'
-#' @param excl A vector of DIF variables that should be excluded.
+#' @param excl A vector of DIF variables that should be excluded. Values are
+#' matched exactly against `DIF.variable`, not as regular expressions or
+#' substrings.
 #' @param label A vector of names for the DIF variables.
 #' @param ... Further arguments passed to [Tbl()]; `digits` is set internally and
 #' will error if also passed here.
@@ -1044,7 +1052,7 @@ TblDifFit <- function(obj, footnote = NULL, excl = NULL, label = NULL,
 
   # Exclude rows
   if (!is.null(excl)) {
-    tab <- tab[!grepl(paste(excl, collapse = "|"), tab$'DIF.variable'), ]
+    tab <- tab[!(tab$'DIF.variable' %in% excl), ]
   }
 
   # Rename variables

--- a/R/technical_report_tables.r
+++ b/R/technical_report_tables.r
@@ -383,7 +383,8 @@ TblMvi <- function(obj, select = NULL, footnote = NULL, sort = "position",
     keep <- colnames(tab) %in% c("Nr.", "item") |
       endsWith(colnames(tab), paste0("_", select))
     tab <- tab[, keep]
-    colnames(tab) <- sub(paste0("_", select), "", colnames(tab))
+    # Strip the trailing group suffix only (anchored, matching the filter above)
+    colnames(tab) <- sub(paste0("_", select, "$"), "", colnames(tab))
   }
 
   # Remove empty rows

--- a/man/TblDif.Rd
+++ b/man/TblDif.Rd
@@ -38,7 +38,8 @@ or a data frame with sheet "estimates" from "dif_poly_TR.xlsx" created by
 
 \item{footnote}{A table note.}
 
-\item{excl}{A vector of column names to exclude.}
+\item{excl}{A vector of column names to exclude. Names are matched exactly,
+not as regular expressions or substrings.}
 
 \item{colnames1}{A named vector of names for the DIF variables included in
 the first line of the table heading; the names indicate the group name in

--- a/man/TblDifFit.Rd
+++ b/man/TblDifFit.Rd
@@ -32,7 +32,9 @@ or a data frame with sheet "estimates" from "dif_poly_TR.xlsx" created by
 
 \item{footnote}{A table note.}
 
-\item{excl}{A vector of DIF variables that should be excluded.}
+\item{excl}{A vector of DIF variables that should be excluded. Values are
+matched exactly against `DIF.variable`, not as regular expressions or
+substrings.}
 
 \item{label}{A vector of names for the DIF variables.}
 

--- a/man/TblMvi.Rd
+++ b/man/TblMvi.Rd
@@ -32,7 +32,10 @@ TblMVI(
 or a data frame with sheet "summary" from "mv_item.xlsx" created by
 [mv_item()].}
 
-\item{select}{An optional name of a specific group to select.}
+\item{select}{An optional name of a specific group to select. Columns whose
+names end in the group suffix (e.g. `"_mixed"`) are kept, along with the
+`"Nr."` and `"item"` columns; the suffix is matched literally, not as a
+regular expression.}
 
 \item{footnote}{An optional table note.}
 
@@ -44,7 +47,8 @@ or a data frame with sheet "summary" from "mv_item.xlsx" created by
 will be applied to all columns; otherwise the length must correspond to the
 number of columns in `obj`.}
 
-\item{excl}{A vector of column names to exclude.}
+\item{excl}{A vector of column names to exclude. Names are matched exactly,
+not as regular expressions or substrings.}
 
 \item{...}{Further arguments passed to [Tbl()].}
 }

--- a/man/TblPars.Rd
+++ b/man/TblPars.Rd
@@ -21,7 +21,8 @@ or a data frame with sheet "summary" from "irt_poly.xlsx" created by
 
 \item{footnote}{A table note.}
 
-\item{excl}{A vector of column names to exclude.}
+\item{excl}{A vector of column names to exclude. Names are matched exactly,
+not as regular expressions or substrings.}
 
 \item{size}{The general font size.}
 

--- a/tests/testthat/test-technical_report_tables.R
+++ b/tests/testthat/test-technical_report_tables.R
@@ -454,3 +454,116 @@ test_that("specialized table functions forward ... to Tbl()", {
 })
 
 
+# Regression tests for #115: excl/select must match whole names exactly, not as
+# unanchored regular expressions / substrings.
+
+test_that("TblMvi() excl matches column names exactly (#115)", {
+
+  skip_if_not_installed("flextable")
+  skip_if_not_installed("officer")
+
+  tab <- Import(test_path("fixtures", "ex1", "tables"), "mv_item.xlsx")
+
+  # "N" is not the exact name of any column, so nothing is excluded. The old
+  # grepl() implementation dropped N_administered, N_valid, NV and NR.
+  keep_all <- names(TblMvi(tab, excl = NULL)$body$dataset)
+  collide <- names(TblMvi(tab, excl = "N")$body$dataset)
+  expect_equal(collide, keep_all)
+  expect_true(all(c("OM", "NV", "NR") %in% collide))
+
+  # The documented defaults still drop their exact columns.
+  def <- names(TblMvi(tab)$body$dataset)
+  expect_false(any(c("Total", "ALL") %in% def))  # N_administered, ALL excluded
+  expect_true(all(c("OM", "NV", "NR") %in% def))
+
+})
+
+
+test_that("TblMvi() select matches the group suffix exactly (#115)", {
+
+  skip_if_not_installed("flextable")
+  skip_if_not_installed("officer")
+
+  # Two groups whose suffixes collide as substrings ("_g" is contained in
+  # "_g2"). select = "g" must keep only the "_g" columns.
+  obj <- data.frame(
+    x = c("", ""),
+    item = c("i1", "i2"),
+    position_g = c(1, 2),
+    N_valid_g = c(10, 20),
+    position_g2 = c(3, 4),
+    N_valid_g2 = c(30, 40),
+    check.names = FALSE,
+    stringsAsFactors = FALSE
+  )
+  colnames(obj)[1] <- ""  # mimic the unnamed first column from openxlsx
+
+  tbl <- TblMvi(obj, select = "g")
+  nms <- names(tbl$body$dataset)
+  # Old grepl("_g") also matched "_g2", leaking "position2"/"N_valid2" columns.
+  expect_equal(nms, c("Nr.", "Item", "Pos.", "N"))
+  expect_false(any(grepl("2$", nms)))
+
+})
+
+
+test_that("TblPars() excl matches column names exactly (#115)", {
+
+  skip_if_not_installed("flextable")
+  skip_if_not_installed("officer")
+
+  tab <- Import(test_path("fixtures", "ex2", "tables"), "irt_poly.xlsx")
+
+  # "N" excludes nothing (no column is named exactly "N"); the old grepl()
+  # dropped N_administered, N_valid and even WMNSQ.
+  keep_all <- names(TblPars(tab, excl = NULL)$body$dataset)
+  collide <- names(TblPars(tab, excl = "N")$body$dataset)
+  expect_equal(collide, keep_all)
+  expect_true(all(c("WMNSQ", "N") %in% collide))
+
+  # Exact name is still excluded.
+  expect_false("N_administered" %in% names(TblPars(tab, excl = "N_administered")$body$dataset))
+
+})
+
+
+test_that("TblDif() excl matches column names exactly (#115)", {
+
+  skip_if_not_installed("flextable")
+  skip_if_not_installed("officer")
+
+  dif <- Import(test_path("fixtures", "ex1", "tables"), "dif_dich_TR.xlsx")
+  hdr1 <- function(ft) as.character(unlist(ft$header$dataset[1, ]))
+
+  all_cols <- hdr1(TblDif(dif))
+  # "mig" is not an exact column name; the old grepl() dropped mig.1-2/1-3/2-3.
+  expect_equal(hdr1(TblDif(dif, excl = "mig")), all_cols)
+  expect_true(all(c("mig.1-2", "mig.1-3", "mig.2-3") %in% all_cols))
+
+  # Exact names (with "." and "-" treated literally) are excluded.
+  dropped <- hdr1(TblDif(dif, excl = c("mig.1-2", "mig.1-3")))
+  expect_false(any(c("mig.1-2", "mig.1-3") %in% dropped))
+  expect_true(all(c("item", "sex.0-1", "mig.2-3") %in% dropped))
+
+})
+
+
+test_that("TblDifFit() excl matches DIF variables exactly (#115)", {
+
+  skip_if_not_installed("flextable")
+  skip_if_not_installed("officer")
+
+  tab <- Import(test_path("fixtures", "ex1", "tables"), "dif_dich_TR.xlsx")
+
+  # "se" is a substring of "sex" but not an exact DIF variable, so the sex rows
+  # are retained (the old grepl() removed them).
+  collide <- TblDifFit(tab, excl = "se")$body$dataset[["DIF variable"]]
+  expect_true(any(grepl("Sex", collide)))
+
+  # The exact name still drops the rows.
+  dropped <- TblDifFit(tab, excl = "sex")$body$dataset[["DIF variable"]]
+  expect_false(any(grepl("Sex", dropped)))
+
+})
+
+

--- a/tests/testthat/test-technical_report_tables.R
+++ b/tests/testthat/test-technical_report_tables.R
@@ -507,6 +507,31 @@ test_that("TblMvi() select matches the group suffix exactly (#115)", {
 })
 
 
+test_that("TblMvi() select strips only the trailing group suffix (#121)", {
+
+  skip_if_not_installed("flextable")
+  skip_if_not_installed("officer")
+
+  # A measure name that itself contains the suffix token ("_g") must keep its
+  # internal "_g"; the rename must strip only the *trailing* "_g" (anchored),
+  # not the first occurrence.
+  obj <- data.frame(
+    x = c("", ""),
+    item = c("i1", "i2"),
+    position_g = c(1, 2),
+    x_g_score_g = c(10, 20),
+    check.names = FALSE,
+    stringsAsFactors = FALSE
+  )
+  colnames(obj)[1] <- ""
+
+  nms <- names(TblMvi(obj, select = "g", excl = NULL)$body$dataset)
+  expect_true("x_g_score" %in% nms)   # anchored: only the trailing "_g" removed
+  expect_false("x_score_g" %in% nms)  # unanchored sub() would have produced this
+
+})
+
+
 test_that("TblPars() excl matches column names exactly (#115)", {
 
   skip_if_not_installed("flextable")


### PR DESCRIPTION
## Summary

Fixes #115. `TblMvi`, `TblPars`, `TblDif` and `TblDifFit` documented `excl` / `select` as *vectors of column names* but filtered with `grepl(paste(excl, collapse = "|"), …)`, which matches **unanchored** and treats each entry as a **regex**. Callers got substring / metacharacter matches instead of exact names — silently producing wrong tables in technical reports.

Examples of the old misbehaviour (now fixed):
- `TblPars(pars, excl = "N")` dropped `N_administered`, `N_valid` **and** `WMNSQ` (all contain "N").
- `TblDif(dif, excl = "mig")` dropped all of `mig.1-2`, `mig.1-3`, `mig.2-3`.

## Changes
- **Column drops** (`TblMvi`, `TblPars`, `TblDif`): exact `!(colnames(tab) %in% excl)`.
- **Row drop** (`TblDifFit`): exact `!(tab$"DIF.variable" %in% excl)`.
- **`TblMvi` `select`**: anchored suffix match `endsWith(colnames(tab), paste0("_", select))` — group columns are `<measure>_<group>`, so this stays a suffix match (not `%in%`); `nzchar()` preserves the old dropping of unnamed columns.
- Clarified the roxygen for `excl` / `select`; regenerated `man/`.
- Added a substring-collision regression test for each of the four functions.

## Acceptance criteria (#115)
- [x] `excl` / `select` match whole names only; metacharacters (`.`, `-`) treated literally.
- [x] `TblMvi(mvi, excl = c("N"))` removes nothing.
- [x] Existing defaults and `excl = ""` / `excl = NULL` behaviour unchanged.
- [x] Regression tests added for each of the 4 functions covering a substring-collision case.
- [x] On current `main` (#109/#110 already merged); no `Nr.` escaping regression from #110.

## Verification
- `devtools::test()` — **382 pass, 0 fail**.
- `devtools::check(args = "--no-tests")` — **0 errors, 0 warnings, 1 NOTE** (pre-existing: `WrightMap`/`sfsmisc` unused imports, tracked in #82/#112).

🤖 Generated with [Claude Code](https://claude.com/claude-code)