### PR TITLE
Make GetPars()/GetDif() condition parsing robust

### DIFF
--- a/R/technical_report_get.r
+++ b/R/technical_report_get.r
@@ -318,7 +318,8 @@ GetPars <- function(obj, type, stat = median, item = FALSE,
     # no summary function available
   } else {
 
-    # turn the condition string into a counting summary function
+    # turn the condition string into a summary function: with item = FALSE it
+    # counts the matches, with item = TRUE it returns the logical mask of matches
     parsed <- parse_conditions(stat)
     stat <- \(x, na.rm, item = FALSE) {
       boolvec <- eval_conditions(parsed, x)
@@ -336,6 +337,8 @@ GetPars <- function(obj, type, stat = median, item = FALSE,
     if (!item) {
       return(rnd(stat(tab[, type], na.rm = TRUE), digits = digits))
     } else {
+      # which() keeps only the matching rows, so items with an NA value are
+      # dropped rather than showing up as "NA" in the returned list
       i <- tab[which(stat(tab[, type], na.rm = TRUE, item = TRUE)), "Item"]
       if (rename_collapsed) i <- gsub("_collapsed", "", i)
       return(paste0(i, collapse = ", "))
@@ -915,7 +918,8 @@ GetDif <- function(obj, n = NULL, main = NULL, dif = NULL,
     # DIF effects without summary function
   } else if (!is.null(dif)) {
 
-    # turn the condition string into a counting summary function
+    # turn the condition string into a summary function: with item = FALSE it
+    # counts the matches, with item = TRUE it returns the logical mask of matches
     parsed <- parse_conditions(dif)
     stat <- \(x, na.rm, item = FALSE) {
       boolvec <- eval_conditions(parsed, x)
@@ -945,6 +949,8 @@ GetDif <- function(obj, n = NULL, main = NULL, dif = NULL,
     if (!item) {
       return(rnd(stat(tab$xsi, na.rm = TRUE), digits))
     } else {
+      # which() keeps only the matching rows, so items with an NA value are
+      # dropped rather than showing up as "NA" in the returned list
       i <- tab[which(stat(tab$xsi, na.rm = TRUE, item = TRUE)), "item"]
       return(paste0(unique(i), collapse = ", "))
     }

--- a/R/technical_report_get.r
+++ b/R/technical_report_get.r
@@ -221,20 +221,23 @@ GetMVP <- GetMvp
 #' @param obj A data frame with sheets from "irt_dich.xlsx" or "irt_poly.xlsx"
 #' created by [irt_analysis()].
 #' @param type A column name in `obj` identifying an item statistic.
-#' @param stat A function used to summarize `type` or a string specifying
-#' an operator (=, <, >) with a number; e.g.,
+#' @param stat A function used to summarize `type` or a single string
+#' specifying a comparison operator (=, ==, !=, <, <=, >, >=) with a number;
+#' e.g.,
 #' * =3 returns number of type equal to 3
 #' * <3 returns number of type less than 3
-#' * >3 returns number of type greater than 3
-#'  Multiple conditions can be combined using & and |.
+#' * >=3 returns number of type greater than or equal to 3
+#' Multiple conditions can be combined within the string using & and |
+#' (e.g. `">1.15 & <1.20"`); surrounding whitespace is ignored.
 #' @param item A logical indicating whether to return the results from stat
 #' (`FALSE`) or the item name corresponding to the value of `stat` (`TRUE`).
-#' @param excl A string specifying an operator (=, <, >) with a number
-#' indicating values to exclude; e.g.,
-#' * =3 excludes number of type equal to 3
-#' * <3 excludes number of type less than 3
-#' * >3 excludes number of type greater than 3
-#' Multiple conditions can be combined using & and |.
+#' @param excl A single string specifying a comparison operator
+#' (=, ==, !=, <, <=, >, >=) with a number indicating values to exclude; e.g.,
+#' * =3 excludes type equal to 3
+#' * <3 excludes type less than 3
+#' * >=3 excludes type greater than or equal to 3
+#' Multiple conditions can be combined within the string using & and |
+#' (e.g. `">1.15 & <1.20"`); surrounding whitespace is ignored.
 #' @param digits A number for rounding.
 #' @returns A number with the calculated statistic or character vector with
 #' item names.
@@ -277,6 +280,9 @@ GetMVP <- GetMvp
 #' # Largest WMNSQ between 1 and 1.2
 #' GetPars(pars, "WMNSQ", max, excl = "<1|>1.2")
 #'
+#' # Number of items with a WMNSQ from 1.15 up to 1.20 (spaces are allowed)
+#' GetPars(pars, "WMNSQ", ">=1.15 & <1.20")
+#'
 #' # Clean up generated files
 #' file.remove(paste0(tmpdir, "/irt_dich.xlsx"))
 #' file.remove(paste0(tmpdir, "/irt_dich.rds"))
@@ -293,36 +299,9 @@ GetPars <- function(obj, type, stat = median, item = FALSE,
   tab <- as.data.frame(obj[["summary"]])
   if (!is.null(excl)) {
 
-    # identify multiple conditions
-    logicals <- base::strsplit(gsub("[^&|]", "", excl), "")[[1]]
-    excl <- base::strsplit(base::trimws(excl), "[&|]")[[1]]
-
-    # identify operator and value for each condition
-    operators <- values <- c()
-    for (i in excl) {
-      if (!(substr(base::trimws(i), 1, 1) %in% c("=", "<", ">")))
-        stop("Unknown stat function.")
-      operators[i] = substr(i, 1, 1)
-      if (operators[i] == "=") operators[i] <- paste0(operators[i], "=")
-      values[i] <- as.numeric(base::trimws(substring(i, 2)))
-    }
-
-    # combine conditions to select data
-    for (i in seq_along(operators)) {
-      if (i == 1) {
-        boolvec <- methods::getFunction(operators[i])(tab[, type], values[i])
-      } else {
-        expr <-
-          call(
-            logicals[i - 1],
-            boolvec,
-            methods::getFunction(operators[i])(tab[, type], values[i])
-          )
-        boolvec <- eval(expr)
-      }
-    }
-    tab <- tab[!boolvec, ]
-    rm(logicals, operators, values, boolvec)
+    # drop rows matching the exclusion condition(s); which() ignores NA cells
+    boolvec <- eval_conditions(parse_conditions(excl), tab[, type])
+    tab <- tab[which(!boolvec), ]
 
   }
 
@@ -339,35 +318,10 @@ GetPars <- function(obj, type, stat = median, item = FALSE,
     # no summary function available
   } else {
 
-    # identify multiple conditions
-    logicals <- base::strsplit(gsub("[^&|]", "", stat), "")[[1]]
-    stat <- base::strsplit(base::trimws(stat), "[&|]")[[1]]
-
-    # identify operator and value for each condition
-    operators <- values <- c()
-    for (i in stat) {
-      if (!(substr(base::trimws(i), 1, 1) %in% c("=", "<", ">")))
-        stop("Unknown stat function.")
-      operators[i] = substr(i, 1, 1)
-      if (operators[i] == "=") operators[i] <- paste0(operators[i], "=")
-      values[i] <- as.numeric(base::trimws(substring(i, 2)))
-    }
-
-    # combine conditions in new summary function
+    # turn the condition string into a counting summary function
+    parsed <- parse_conditions(stat)
     stat <- \(x, na.rm, item = FALSE) {
-      for (i in seq_along(operators)) {
-        if (i == 1) {
-          boolvec <- methods::getFunction(operators[i])(x, values[i])
-        } else {
-          expr <-
-            call(
-              logicals[i - 1],
-              boolvec,
-              methods::getFunction(operators[i])(x, values[i])
-            )
-          boolvec <- eval(expr)
-        }
-      }
+      boolvec <- eval_conditions(parsed, x)
       if (item) {
         return(boolvec)
       } else {
@@ -382,7 +336,7 @@ GetPars <- function(obj, type, stat = median, item = FALSE,
     if (!item) {
       return(rnd(stat(tab[, type], na.rm = TRUE), digits = digits))
     } else {
-      i <- tab[stat(tab[, type], na.rm = TRUE, item = TRUE), "Item"]
+      i <- tab[which(stat(tab[, type], na.rm = TRUE, item = TRUE)), "Item"]
       if (rename_collapsed) i <- gsub("_collapsed", "", i)
       return(paste0(i, collapse = ", "))
     }
@@ -832,12 +786,14 @@ GetDim <- function(obj, model = "dim", stat = median, var = FALSE,
 #' and `group` is missing, results for the first group comparison are returned.
 #' @param group If the DIF variable has more than two groups, the name of
 #' the group comparison.
-#' @param dif A function used to summarize the DIF effects or a string
-#' specifying an operator (=, <, >) with a number; e.g.,
+#' @param dif A function used to summarize the DIF effects or a single string
+#' specifying a comparison operator (=, ==, !=, <, <=, >, >=) with a number;
+#' e.g.,
 #' * =1 returns number of DIF effects equal to 1
 #' * <1 returns number of DIF effects less than 1
-#' * >1 returns number of DIF effects greater than 1
-#' Multiple conditions can be combined using & and |.
+#' * >=1 returns number of DIF effects greater than or equal to 1
+#' Multiple conditions can be combined within the string using & and |
+#' (e.g. `">.4 | <.05"`); surrounding whitespace is ignored.
 #' If the DIF variable has more than two group and `group` is missing, results
 #' across all groups are returned.
 #' @param item A logical to return the item names (`TRUE`) instead of the
@@ -959,35 +915,10 @@ GetDif <- function(obj, n = NULL, main = NULL, dif = NULL,
     # DIF effects without summary function
   } else if (!is.null(dif)) {
 
-    # identify multiple conditions
-    logicals <- strsplit(gsub("[^&|]", "", dif), "")[[1]]
-    stat <- strsplit(trimws(dif), "[&|]")[[1]]
-
-    # identify operator and value for each condition
-    operators <- values <- c()
-    for (i in stat) {
-      if (!(substr(trimws(i), 1, 1) %in% c("=", "<", ">")))
-        stop("Unknown stat function.")
-      operators[i] = substr(i, 1, 1)
-      if (operators[i] == "=") operators[i] <- paste0(operators[i], "=")
-      values[i] <- as.numeric(trimws(substring(i, 2)))
-    }
-
-    # combine conditions in new summary function
+    # turn the condition string into a counting summary function
+    parsed <- parse_conditions(dif)
     stat <- \(x, na.rm, item = FALSE) {
-      for (i in seq_along(operators)) {
-        if (i == 1) {
-          boolvec <- methods::getFunction(operators[i])(x, values[i])
-        } else {
-          expr <-
-            call(
-              logicals[i - 1],
-              boolvec,
-              methods::getFunction(operators[i])(x, values[i])
-            )
-          boolvec<- eval(expr)
-        }
-      }
+      boolvec <- eval_conditions(parsed, x)
       if (item) {
         return(boolvec)
       } else {
@@ -1014,7 +945,7 @@ GetDif <- function(obj, n = NULL, main = NULL, dif = NULL,
     if (!item) {
       return(rnd(stat(tab$xsi, na.rm = TRUE), digits))
     } else {
-      i <- tab[stat(tab$xsi, na.rm = TRUE, item = TRUE), "item"]
+      i <- tab[which(stat(tab$xsi, na.rm = TRUE, item = TRUE)), "item"]
       return(paste0(unique(i), collapse = ", "))
     }
 

--- a/R/technical_report_get.r
+++ b/R/technical_report_get.r
@@ -222,7 +222,7 @@ GetMVP <- GetMvp
 #' created by [irt_analysis()].
 #' @param type A column name in `obj` identifying an item statistic.
 #' @param stat A function used to summarize `type` or a single string
-#' specifying a comparison operator (=, ==, !=, <, <=, >, >=) with a number;
+#' specifying a comparison operator (=, ==, !=, <, <=, >, >=; use >= / <=, not the reversed =>/=<) with a number;
 #' e.g.,
 #' * =3 returns number of type equal to 3
 #' * <3 returns number of type less than 3
@@ -232,7 +232,7 @@ GetMVP <- GetMvp
 #' @param item A logical indicating whether to return the results from stat
 #' (`FALSE`) or the item name corresponding to the value of `stat` (`TRUE`).
 #' @param excl A single string specifying a comparison operator
-#' (=, ==, !=, <, <=, >, >=) with a number indicating values to exclude; e.g.,
+#' (=, ==, !=, <, <=, >, >=; use >= / <=, not the reversed =>/=<) with a number indicating values to exclude; e.g.,
 #' * =3 excludes type equal to 3
 #' * <3 excludes type less than 3
 #' * >=3 excludes type greater than or equal to 3
@@ -787,7 +787,7 @@ GetDim <- function(obj, model = "dim", stat = median, var = FALSE,
 #' @param group If the DIF variable has more than two groups, the name of
 #' the group comparison.
 #' @param dif A function used to summarize the DIF effects or a single string
-#' specifying a comparison operator (=, ==, !=, <, <=, >, >=) with a number;
+#' specifying a comparison operator (=, ==, !=, <, <=, >, >=; use >= / <=, not the reversed =>/=<) with a number;
 #' e.g.,
 #' * =1 returns number of DIF effects equal to 1
 #' * <1 returns number of DIF effects less than 1

--- a/R/utils.R
+++ b/R/utils.R
@@ -913,9 +913,12 @@ parse_conditions <- function(cond) {
   # split into individual comparisons and trim surrounding whitespace
   parts <- base::trimws(base::strsplit(base::trimws(cond), "[&|]")[[1]])
 
+  # split each comparison into its operator and the number to compare against
   operators <- character(length(parts))
   values <- numeric(length(parts))
   for (k in seq_along(parts)) {
+    # grab the leading operator; 2-char forms are listed first so e.g. ">="
+    # matches before ">" (=> and =< are matched here only to reject them below)
     op <- base::regmatches(parts[k], base::regexpr("^(<=|>=|=>|=<|==|!=|=|<|>)", parts[k]))
     if (length(op) == 0L)
       stop("Unknown stat function.")
@@ -923,7 +926,8 @@ parse_conditions <- function(cond) {
     if (op == "=>" || op == "=<")
       stop("Unknown operator '", op, "' in condition '", parts[k],
            "': did you mean '", if (op == "=>") ">=" else "<=", "'?")
-    operators[k] <- if (op == "=") "==" else op
+    operators[k] <- if (op == "=") "==" else op   # treat "=" as R's "=="
+    # whatever follows the operator has to be a number, otherwise error
     value <- suppressWarnings(
       as.numeric(base::trimws(base::sub("^(<=|>=|==|!=|=|<|>)", "", parts[k]))))
     if (is.na(value))
@@ -943,6 +947,9 @@ parse_conditions <- function(cond) {
 # @noRd
 eval_conditions <- function(parsed, x) {
 
+  # getFunction() looks up the function named by a string, so
+  # getFunction(">")(x, 1.2) is x > 1.2 and getFunction("&")(a, b) is a & b.
+  # start from the first comparison, then fold in the rest left-to-right.
   boolvec <- methods::getFunction(parsed$operators[1L])(x, parsed$values[1L])
   for (k in seq_along(parsed$operators)[-1L]) {
     cur <- methods::getFunction(parsed$operators[k])(x, parsed$values[k])

--- a/R/utils.R
+++ b/R/utils.R
@@ -890,3 +890,64 @@ recodeVar <- function(x, src, tgt, default = NULL, keep.na = TRUE) {
 capitalize <- function(x) {
   paste0(toupper(substr(x, 1, 1)), substr(x, 2, nchar(x)))
 }
+
+
+# Internal helper: parse a string condition used by GetPars()/GetDif().
+# A condition is a single string such as ">1.15", ">1.15 & <1.20", or
+# "<1 | >1.2": comparison operators (=, ==, !=, <, <=, >, >=) are combined
+# with the logical connectors & (and) and | (or). Surrounding whitespace is
+# ignored. An unrecognised operator, the reversed forms => / =<, or a
+# non-numeric value each raise an error. Returns the operators, their numeric
+# values, and the connectors in their original order.
+# @noRd
+parse_conditions <- function(cond) {
+
+  cond <- as.character(cond)
+  if (length(cond) != 1L)
+    stop("Provide a single condition string; combine filters with '&' or '|', ",
+         "e.g. \">1.15 & <1.20\".")
+
+  # logical connectors (& or |) in their original order
+  logicals <- base::strsplit(base::gsub("[^&|]", "", cond), "")[[1]]
+
+  # split into individual comparisons and trim surrounding whitespace
+  parts <- base::trimws(base::strsplit(base::trimws(cond), "[&|]")[[1]])
+
+  operators <- character(length(parts))
+  values <- numeric(length(parts))
+  for (k in seq_along(parts)) {
+    op <- base::regmatches(parts[k], base::regexpr("^(<=|>=|=>|=<|==|!=|=|<|>)", parts[k]))
+    if (length(op) == 0L)
+      stop("Unknown stat function.")
+    # reject the reversed forms of >= and <= with a helpful hint
+    if (op == "=>" || op == "=<")
+      stop("Unknown operator '", op, "' in condition '", parts[k],
+           "': did you mean '", if (op == "=>") ">=" else "<=", "'?")
+    operators[k] <- if (op == "=") "==" else op
+    value <- suppressWarnings(
+      as.numeric(base::trimws(base::sub("^(<=|>=|==|!=|=|<|>)", "", parts[k]))))
+    if (is.na(value))
+      stop("Invalid number in condition '", parts[k], "'.")
+    values[k] <- value
+  }
+
+  list(operators = operators, values = values, logicals = logicals)
+
+}
+
+
+# Internal helper: evaluate parsed conditions against a numeric vector. The
+# individual comparisons are folded left-to-right with their logical connectors
+# (e.g. "<1 | >1.2" becomes (x < 1) | (x > 1.2)). Returns a logical vector the
+# same length as x.
+# @noRd
+eval_conditions <- function(parsed, x) {
+
+  boolvec <- methods::getFunction(parsed$operators[1L])(x, parsed$values[1L])
+  for (k in seq_along(parsed$operators)[-1L]) {
+    cur <- methods::getFunction(parsed$operators[k])(x, parsed$values[k])
+    boolvec <- methods::getFunction(parsed$logicals[k - 1L])(boolvec, cur)
+  }
+  boolvec
+
+}

--- a/dev/11_notifications.md
+++ b/dev/11_notifications.md
@@ -570,10 +570,13 @@ Messages 57–67 are all `message()` calls emitted when `verbose = TRUE` (the de
 
 | # | Type | Message text (abbreviated) | Trigger | Effect |
 |---|------|---------------------------|---------|--------|
-| 137 | **error** | *"Unknown stat function."* (in `GetPars()` `excl` branch) | An exclusion condition string does not start with `=`, `<`, or `>`. | Execution stops. Only simple comparison operators are supported in the `excl` argument. |
-| 138 | **error** | *"Unknown stat function."* (in `GetPars()` `stat` branch) | A statistic condition string does not start with `=`, `<`, or `>`. | Execution stops. Analogous to #137. |
+| 137 | **error** | *"Unknown stat function."* (in `GetPars()` `excl` branch) | An exclusion condition does not begin with a recognised comparison operator (`=`, `==`, `!=`, `<`, `<=`, `>`, `>=`). | Execution stops. Combine multiple conditions inside one string with `&`/`|`. |
+| 138 | **error** | *"Unknown stat function."* (in `GetPars()` `stat` branch) | A statistic condition does not begin with a recognised comparison operator. | Execution stops. Analogous to #137. |
 | 139 | **error** | *"Allowed values for argument main are 'std' and 'ustd'."* (in `GetDif()` `main` argument validation) | `main` is not `"std"` or `"ustd"`. | Execution stops. Only standardised and unstandardised effect-size variants are implemented. |
-| 140 | **error** | *"Unknown stat function."* (in `GetDif()` `dif` branch) | A DIF condition string uses an unsupported operator. | Execution stops. Analogous to #137. |
+| 140 | **error** | *"Unknown stat function."* (in `GetDif()` `dif` branch) | A DIF condition does not begin with a recognised comparison operator. | Execution stops. Analogous to #137. |
+| 141 | **error** | *"Provide a single condition string; combine filters with '&' or '|', …"* (in the shared `parse_conditions()` helper) | A condition argument (`excl`/`stat`/`dif`) is a character vector of length > 1 instead of a single string. | Execution stops. Pass one string and join filters with `&`/`|`, e.g. `">1.15 & <1.20"`. |
+| 142 | **error** | *"Unknown operator '=>' in condition '…': did you mean '>='?"* (in `parse_conditions()`) | A condition uses the reversed form `=>` or `=<` instead of `>=`/`<=`. | Execution stops with a hint to use the correct operator. |
+| 143 | **error** | *"Invalid number in condition '…'."* (in `parse_conditions()`) | The text after a comparison operator is not a number (e.g. a malformed operator such as `><1`, or a missing number such as `>`). | Execution stops instead of silently producing an `NA` comparison. |
 
 ---
 
@@ -581,9 +584,9 @@ Messages 57–67 are all `message()` calls emitted when `verbose = TRUE` (the de
 
 | Notification type | Count |
 |-------------------|------:|
-| **error** (`stop()`) | 46 |
+| **error** (`stop()`) | 49 |
 | **warning** | 24 |
 | **message** | 70 |
-| **Total** | **140** |
+| **Total** | **143** |
 
 > **Note:** Counts reflect all distinct notification call-sites in the package source at the time of writing.  The same underlying condition may be triggered multiple times during a single analysis run (e.g., once per group or per item).

--- a/man/GetDif.Rd
+++ b/man/GetDif.Rd
@@ -40,12 +40,14 @@ GetDIF(
 main effects (`ustd`). If the DIF variable has more than two groups
 and `group` is missing, results for the first group comparison are returned.}
 
-\item{dif}{A function used to summarize the DIF effects or a string
-specifying an operator (=, <, >) with a number; e.g.,
+\item{dif}{A function used to summarize the DIF effects or a single string
+specifying a comparison operator (=, ==, !=, <, <=, >, >=) with a number;
+e.g.,
 * =1 returns number of DIF effects equal to 1
 * <1 returns number of DIF effects less than 1
-* >1 returns number of DIF effects greater than 1
-Multiple conditions can be combined using & and |.
+* >=1 returns number of DIF effects greater than or equal to 1
+Multiple conditions can be combined within the string using & and |
+(e.g. `">.4 | <.05"`); surrounding whitespace is ignored.
 If the DIF variable has more than two group and `group` is missing, results
 across all groups are returned.}
 

--- a/man/GetDif.Rd
+++ b/man/GetDif.Rd
@@ -41,7 +41,7 @@ main effects (`ustd`). If the DIF variable has more than two groups
 and `group` is missing, results for the first group comparison are returned.}
 
 \item{dif}{A function used to summarize the DIF effects or a single string
-specifying a comparison operator (=, ==, !=, <, <=, >, >=) with a number;
+specifying a comparison operator (=, ==, !=, <, <=, >, >=; use >= / <=, not the reversed =>/=<) with a number;
 e.g.,
 * =1 returns number of DIF effects equal to 1
 * <1 returns number of DIF effects less than 1

--- a/man/GetPars.Rd
+++ b/man/GetPars.Rd
@@ -21,7 +21,7 @@ created by [irt_analysis()].}
 \item{type}{A column name in `obj` identifying an item statistic.}
 
 \item{stat}{A function used to summarize `type` or a single string
-specifying a comparison operator (=, ==, !=, <, <=, >, >=) with a number;
+specifying a comparison operator (=, ==, !=, <, <=, >, >=; use >= / <=, not the reversed =>/=<) with a number;
 e.g.,
 * =3 returns number of type equal to 3
 * <3 returns number of type less than 3
@@ -33,7 +33,7 @@ Multiple conditions can be combined within the string using & and |
 (`FALSE`) or the item name corresponding to the value of `stat` (`TRUE`).}
 
 \item{excl}{A single string specifying a comparison operator
-(=, ==, !=, <, <=, >, >=) with a number indicating values to exclude; e.g.,
+(=, ==, !=, <, <=, >, >=; use >= / <=, not the reversed =>/=<) with a number indicating values to exclude; e.g.,
 * =3 excludes type equal to 3
 * <3 excludes type less than 3
 * >=3 excludes type greater than or equal to 3

--- a/man/GetPars.Rd
+++ b/man/GetPars.Rd
@@ -20,22 +20,25 @@ created by [irt_analysis()].}
 
 \item{type}{A column name in `obj` identifying an item statistic.}
 
-\item{stat}{A function used to summarize `type` or a string specifying
-an operator (=, <, >) with a number; e.g.,
+\item{stat}{A function used to summarize `type` or a single string
+specifying a comparison operator (=, ==, !=, <, <=, >, >=) with a number;
+e.g.,
 * =3 returns number of type equal to 3
 * <3 returns number of type less than 3
-* >3 returns number of type greater than 3
- Multiple conditions can be combined using & and |.}
+* >=3 returns number of type greater than or equal to 3
+Multiple conditions can be combined within the string using & and |
+(e.g. `">1.15 & <1.20"`); surrounding whitespace is ignored.}
 
 \item{item}{A logical indicating whether to return the results from stat
 (`FALSE`) or the item name corresponding to the value of `stat` (`TRUE`).}
 
-\item{excl}{A string specifying an operator (=, <, >) with a number
-indicating values to exclude; e.g.,
-* =3 excludes number of type equal to 3
-* <3 excludes number of type less than 3
-* >3 excludes number of type greater than 3
-Multiple conditions can be combined using & and |.}
+\item{excl}{A single string specifying a comparison operator
+(=, ==, !=, <, <=, >, >=) with a number indicating values to exclude; e.g.,
+* =3 excludes type equal to 3
+* <3 excludes type less than 3
+* >=3 excludes type greater than or equal to 3
+Multiple conditions can be combined within the string using & and |
+(e.g. `">1.15 & <1.20"`); surrounding whitespace is ignored.}
 
 \item{digits}{A number for rounding.}
 
@@ -85,6 +88,9 @@ GetPars(pars, "xsi", "<-2", item = TRUE)
 
 # Largest WMNSQ between 1 and 1.2
 GetPars(pars, "WMNSQ", max, excl = "<1|>1.2")
+
+# Number of items with a WMNSQ from 1.15 up to 1.20 (spaces are allowed)
+GetPars(pars, "WMNSQ", ">=1.15 & <1.20")
 
 # Clean up generated files
 file.remove(paste0(tmpdir, "/irt_dich.xlsx"))

--- a/tests/testthat/test-technical_report_get.R
+++ b/tests/testthat/test-technical_report_get.R
@@ -116,6 +116,33 @@ test_that("GetPars() works", {
     "0.5"
   )
 
+  # robustness: whitespace around &/| is tolerated (same result as no spaces)
+  expect_equal(GetPars(pars, type = "WMNSQ", stat = max, excl = "<1 | >1.1"), "1.03")
+  expect_equal(GetPars(pars, type = "N_valid", stat = "<600 | >900"), "11")
+
+  # robustness: two-character operators >= and <= are supported
+  expect_equal(
+    GetPars(pars, type = "N_valid", stat = ">=600"),
+    GetPars(pars, type = "N_valid", stat = ">599")
+  )
+  expect_equal(
+    GetPars(pars, type = "N_valid", stat = "<=900"),
+    GetPars(pars, type = "N_valid", stat = "<901")
+  )
+
+  # robustness: a vector of filters is rejected (combine with & or | instead)
+  expect_error(
+    GetPars(pars, type = "WMNSQ", stat = max, excl = c(">1.15", "<1.20")),
+    "single condition"
+  )
+
+  # robustness: the reversed operator => is rejected with a hint (R uses >=)
+  expect_error(
+    GetPars(pars, type = "WMNSQ", stat = "=>1.15"),
+    "did you mean '>='",
+    fixed = TRUE
+  )
+
   expect_error(
     GetPars(pars, type = "WMNSQ", stat = "+1"),
     "Unknown stat function.",
@@ -335,6 +362,9 @@ test_that("GetDIF() works", {
   expect_equal(GetDif(mig, main = "ustd", group = "1-3", model = "main"), "0.40")
 
   expect_equal(GetDif(mig, dif = ">.4|<.05"), "10")
+  # robustness: whitespace around &/| tolerated; >= supported (no xsi is exactly .4)
+  expect_equal(GetDif(mig, dif = ">.4 | <.05"), "10")
+  expect_equal(GetDif(mig, dif = ">=.4"), GetDif(mig, dif = ">.4"))
   expect_equal(GetDif(mig, dif = median), "0.14")
   expect_equal(GetDif(mig, dif = "<0.1", signed = FALSE, group = "1-2"), "7")
   expect_equal(

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -498,3 +498,66 @@ test_that("rnd() works", {
   expect_equal(rnd(c(0.042, -0.1459), d0 = TRUE), c(".04", "-.15"))
 
 })
+
+
+test_that("parse_conditions() parses operators, values and connectors", {
+
+  # single comparison; no logical connectors
+  expect_equal(
+    parse_conditions(">1.15"),
+    list(operators = ">", values = 1.15, logicals = character(0))
+  )
+
+  # "=" is normalised to "=="; two-character operators are supported
+  expect_equal(parse_conditions("=3")$operators, "==")
+  expect_equal(parse_conditions(">=1.15")$operators, ">=")
+  expect_equal(parse_conditions("<=1.2")$operators, "<=")
+  expect_equal(parse_conditions("!=0")$operators, "!=")
+
+  # multiple conditions: operators, values and connectors captured in order
+  p <- parse_conditions("<1 | >1.2 & =1.1")
+  expect_equal(p$operators, c("<", ">", "=="))
+  expect_equal(p$values, c(1, 1.2, 1.1))
+  expect_equal(p$logicals, c("|", "&"))
+
+  # whitespace around operators and connectors is tolerated
+  expect_equal(parse_conditions(" > 1.15 & <= 1.20 "),
+               parse_conditions(">1.15&<=1.20"))
+
+  # a vector of conditions is rejected with a helpful message
+  expect_error(parse_conditions(c(">1.15", "<1.20")), "single condition")
+
+  # an unknown operator keeps the historical error message
+  expect_error(parse_conditions("+1"), "Unknown stat function.", fixed = TRUE)
+
+  # the reversed forms => and =< are rejected with a hint (R uses >= / <=)
+  expect_error(parse_conditions("=>1.15"), "did you mean '>='", fixed = TRUE)
+  expect_error(parse_conditions("=<1.15"), "did you mean '<='", fixed = TRUE)
+
+  # a malformed operator or missing number errors instead of coercing to NA
+  expect_error(parse_conditions("><1"), "Invalid number", fixed = TRUE)
+  expect_error(parse_conditions(">"), "Invalid number", fixed = TRUE)
+
+})
+
+
+test_that("eval_conditions() folds comparisons left-to-right", {
+
+  x <- c(0.90, 1.00, 1.10, 1.16, 1.18, 1.25)
+
+  expect_equal(eval_conditions(parse_conditions(">1.15"), x),
+               c(FALSE, FALSE, FALSE, TRUE, TRUE, TRUE))
+
+  # AND keeps only the in-band values
+  expect_equal(eval_conditions(parse_conditions(">1.15 & <1.20"), x),
+               c(FALSE, FALSE, FALSE, TRUE, TRUE, FALSE))
+
+  # >= includes the boundary value (1.16)
+  expect_equal(eval_conditions(parse_conditions(">=1.16"), x),
+               c(FALSE, FALSE, FALSE, TRUE, TRUE, TRUE))
+
+  # spaces give the same result as no spaces
+  expect_equal(eval_conditions(parse_conditions("<1 | >1.2"), x),
+               eval_conditions(parse_conditions("<1|>1.2"), x))
+
+})


### PR DESCRIPTION
## Summary

Makes the string-condition parser behind `GetPars(stat=, excl=)` and `GetDif(dif=)` robust. The same ~25-line parser was **duplicated three times** in `R/technical_report_get.r`; it is now a single pair of internal helpers in `R/utils.R` (`parse_conditions()` / `eval_conditions()`), and several silent-failure modes are fixed.

## Bugs fixed

| Input | Before | After |
|---|---|---|
| `">1.15 & <1.20"` (spaces around `&`/`\|`) | `Error: no function ' ' found` | parses correctly |
| `">=1.15"`, `"<=1.15"` | value coerced to `NA` → garbage | supported |
| `"=>1.15"`, `"=<1.15"` (reversed) | silently mis-parsed to `==` + `NA` | **rejected** with `did you mean '>='?` |
| `"><1"`, bare `">"` | silent `NA` comparison | `Invalid number in condition …` |
| `c(">1.15","<1.20")` (vector) | silently keeps only the first | clear error: use one string + `&`/`\|` |
| `NA` cells in the column | injected as `NA` rows | ignored via `which()` |

## Backward compatibility

Every existing input (single string, no spaces, `> < = & |`) parses to **identical** operators/values/order and identical results — confirmed by the existing tests running against real fixture `pars`/`dif`. The legacy `"Unknown stat function."` error for unrecognised operators is preserved.

## Design note

The reversed forms `=>` / `=<` are **rejected with a hint** rather than auto-corrected, so a typo stops the report render instead of silently guessing intent. (Net effect either way is no more silent wrong numbers.)

## Testing

- `devtools::test()` — **394 pass, 0 fail, 0 warn** (adds direct unit tests for the helpers in `test-utils.R` and integration tests in `test-technical_report_get.R`).
- `devtools::check(args = "--no-tests")` — **0 errors, 0 warnings**, 2 pre-existing NOTEs (timestamp; unused `WrightMap`/`sfsmisc` imports + `:::` — not introduced here).
- New errors catalogued in `dev/11_notifications.md` (#141–#143).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
